### PR TITLE
fix: chore(deps) update Larastan to latest and trigger a release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "^8.1",
         "ekino/phpstan-banned-code": "^1.0",
-        "larastan/larastan": "^2.7.0",
+        "larastan/larastan": "^2.8.0",
         "phpstan/phpstan-mockery": "^1.1"
     },
     "license": "MIT",


### PR DESCRIPTION
Triggering a release so we can increase the version requirements in [stickee/canary](https://github.com/stickeeuk/canary), then trigger a release in Canary, and then we can "force" the new version on projects that need their configs updating to work with this new release.

Shorter version:
if this was just a dependency update we wouldn't need to do this, but because it's a dependency update AND a "fix" then we do.