### PR TITLE
chore(deps): last working config phpstan v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,9 @@
     "description": "stickee's Larastan config",
     "require": {
         "php": "^8.1",
-        "ekino/phpstan-banned-code": "^2.0",
-        "larastan/larastan": "^2.9.6",
+        "ekino/phpstan-banned-code": "^1.0",
+        "larastan/larastan": "2.9.8",
+        "phpstan/phpstan": "1.11.7",
         "phpstan/phpstan-mockery": "^1.1"
     },
     "license": "MIT",


### PR DESCRIPTION
This PR locks the PHPStan dependency to v1.11.7, the last known working config that did not produce hundreds of errors analysing the supermarket mobiles repo.

After this we will target [PHPStan v2](https://phpstan.org/blog/phpstan-2-0-released-level-10-elephpants).